### PR TITLE
Приводим verbose name к строковому представлению в функции преобразования данных объекта log

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='sw-django-logger',
-    version='0.0.16',
+    version='0.0.17',
     description='Log handling and representing for django projects',
     author='Telminov Sergey',
     author_email='sergey@telminov.ru',

--- a/sw_logger/tools.py
+++ b/sw_logger/tools.py
@@ -106,12 +106,12 @@ def object_display_from_log(log: models.Log) -> Optional[dict]:
         if isinstance(value, list):
             value = ', '.join(value)
 
-        display_data[field.verbose_name] = value
+        display_data[str(field.verbose_name)] = value
 
     for field in model._meta.many_to_many:
         value = object_data.get(field.name, [])
         related_qs = field.related_model.objects.filter(pk__in=value)
-        display_data[field.verbose_name] = ', '.join(sorted([str(i) for i in related_qs]))
+        display_data[str(field.verbose_name)] = ', '.join(sorted([str(i) for i in related_qs]))
 
     return display_data
 


### PR DESCRIPTION
Столкнулись со случаями, когда verbose name - функция, а не строка. На примере моделей, наследуемых от абстрактных моделей.